### PR TITLE
fix(build): await build before logging remix compile time

### DIFF
--- a/.remix/build.mjs
+++ b/.remix/build.mjs
@@ -16,10 +16,8 @@ async function command() {
     browser: createBrowserCompiler(require("./webpack.config.browser.js")),
     server: createServerCompiler(require("./webpack.config.server.js")),
   });
-  const { browser, server } = build(remixConfig, compiler);
-  await Promise.all([browser, server]).then(([a, b]) => {
-    console.timeEnd("Remix Compile");
-  });
+  await build(remixConfig, compiler);
+  console.timeEnd("Remix Compile");
 }
 
 command()


### PR DESCRIPTION
`build` API changed to return a single promise